### PR TITLE
Add support for Ed25519 keys

### DIFF
--- a/lib/Net/SSH/AuthorizedKey/SSH2.pm
+++ b/lib/Net/SSH/AuthorizedKey/SSH2.pm
@@ -10,7 +10,7 @@ use Log::Log4perl qw(:easy);
   # No additional options, only global ones
 our %VALID_OPTIONS = ();
 
-our $KEYTYPE_REGEX = qr/rsa|dsa|ssh-rsa|ssh-dss|ecdsa-\S+/;
+our $KEYTYPE_REGEX = qr/rsa|dsa|ssh-rsa|ssh-dss|ssh-ed25519|ecdsa-\S+/;
 
 our @REQUIRED_FIELDS = qw(
     encryption

--- a/t/002Ssh-2.t
+++ b/t/002Ssh-2.t
@@ -10,7 +10,7 @@ use Log::Log4perl qw(:easy);
 use File::Copy;
 # Log::Log4perl->easy_init($DEBUG);
 
-use Test::More tests => 14;
+use Test::More tests => 16;
 BEGIN { use_ok('Net::SSH::AuthorizedKeysFile') };
 
 my $tdir = "t";
@@ -65,3 +65,14 @@ is($keys[1]->type(), "ssh-2", "type");
 
 is($keys[0]->key(), "AAAAAlkj2lkjalsdfkjlaskdfj234", "key");
 is($keys[1]->key(), "AAAAAlkj2lkjalsdfkjlaskdfj234", "key");
+
+# Ed25519 support
+
+$ak = Net::SSH::AuthorizedKeysFile->new(file => "$cdir/ak-ed25519.txt");
+$ak->read();
+
+@keys = $ak->keys();
+
+is($keys[0]->type(), "ssh-2", "type"); # ed25519
+
+is($keys[0]->key(), "AAAAAlkj2lkjalsdfkjlaskdfj234", "key");

--- a/t/canned/ak-ed25519.txt
+++ b/t/canned/ak-ed25519.txt
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAAlkj2lkjalsdfkjlaskdfj234 foo@bar.com


### PR DESCRIPTION
lib/Net/SSH/AuthorizedKey/SSH2.pm: add support for the "ssh-ed25519" prefix
t/002Ssh-2.t: test processing t/canned/ak-ed25519.txt
t/canned/ak-ed25519.txt: authorized_keys test case
