### PR TITLE
Don't print empty lines in read() with Log4perl loglevel below ERROR

### DIFF
--- a/lib/Net/SSH/AuthorizedKeysFile.pm
+++ b/lib/Net/SSH/AuthorizedKeysFile.pm
@@ -123,8 +123,6 @@ sub line_parse {
 
     DEBUG "Parsing line [$line]";
 
-    $self->error( "" );
-
     my $pk = Net::SSH::AuthorizedKey->parse( $line );
 
     if( !$pk ) {


### PR DESCRIPTION
IF you use this module from code that is using Log4perl and initialize
INFO loglevel (or any level below ERROR), the read() function prints
a blank line for every public key read from the keys file.
